### PR TITLE
chore: add louzt as contributor

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -957,4 +957,15 @@
     <sub>Usman Yousaf</sub>
 <!-- End of column-79 -->
 </tr>
+<tr>
+<!-- Start of column-80 -->
+<td align="center">
+  <a href="https://github.com/louzt">
+    <img src="https://github.com/louzt.png" width="100px" />
+    <br />
+    <sub>David Mireles</sub>
+  </a>
+</td>
+<!-- End of column-80 -->
+</tr>
 </table>


### PR DESCRIPTION
Adds David Mireles (louzt) to the Contributors table.

Ref: CommunityPro/support#1042